### PR TITLE
Bind Label with Checkbox

### DIFF
--- a/app/views/settings/_checkboxes.html.erb
+++ b/app/views/settings/_checkboxes.html.erb
@@ -11,8 +11,9 @@
 
 <div class="tabular settings">
 		<% settings_labels.each do |setting, label| %>
-			<p><label><%= l(label) %></label>
-			<%= check_box_tag("settings[#{setting}]",0,@settings[setting.to_s]) %>
+			<p>
+				<label for="settings_<%= setting %>"><%= l(label) %></label>
+				<%= check_box_tag("settings[#{setting}]",0,@settings[setting.to_s]) %>
 			</p>
 		<% end %>
 </div>


### PR DESCRIPTION
Add property "for" for labels and put checkbox ID as value.
This bind label tag with checkbox. Users can also click on the label
to check or unckeck the checkbox.

Note: the way to create label property `for="settings_<%= setting %>"` is not good. I try `label_tag()` before, but figure out it only support in `Rails 2.0.3` and newer version. Please let me know if there is a better way. Thanks.