### PR TITLE
Fix text color of search box

### DIFF
--- a/assets/stylesheets/redmine_improved_searchbox.css
+++ b/assets/stylesheets/redmine_improved_searchbox.css
@@ -1,1 +1,1 @@
-#header a.chzn-single, #project_quick_jump_box_chzn { color:black; }
+#header a.chosen-single, #project_quick_jump_box_chosen { color:black; }


### PR DESCRIPTION
Somehow the css classes of "chosen" changed from "chzn" to "chosen". This caused the search box to be "empty" (white text on white background).